### PR TITLE
bump source-tag & deps

### DIFF
--- a/1.23.3/rockcraft.yaml
+++ b/1.23.3/rockcraft.yaml
@@ -1,4 +1,4 @@
-name: istio-ztunnel
+name: ztunnel
 base: ubuntu@24.04
 version: '1.23.3'
 summary: Ztunnel provides an implementation of the ztunnel component of ambient mesh

--- a/1.24.3/rockcraft.yaml
+++ b/1.24.3/rockcraft.yaml
@@ -1,6 +1,6 @@
 name: istio-ztunnel
 base: ubuntu@24.04
-version: '1.24.1'
+version: '1.24.3'
 summary: Ztunnel provides an implementation of the ztunnel component of ambient mesh
 description: |
   Ztunnel is intended to be a purpose built implementation of the node proxy in ambient mesh. Part of the goals of this included keeping a narrow feature set, implementing only the bare minimum requirements for ambient. This ensures the project remains simple and high performance.
@@ -18,8 +18,8 @@ parts:
   build:
     plugin: rust
     source: https://github.com/istio/ztunnel.git
-    source-tag: 1.24.1
-    rust-channel: 1.81.0
+    source-tag: 1.24.3
+    rust-channel: 1.84.1
     build-packages:
       - protobuf-compiler
   # install packages provided by the istio/iptables distroless image, which is a base for ztunnel

--- a/1.24.3/rockcraft.yaml
+++ b/1.24.3/rockcraft.yaml
@@ -1,4 +1,4 @@
-name: istio-ztunnel
+name: ztunnel
 base: ubuntu@24.04
 version: '1.24.3'
 summary: Ztunnel provides an implementation of the ztunnel component of ambient mesh


### PR DESCRIPTION
## Issue
Fix for https://github.com/canonical/oci-factory/actions/runs/13135280054/attempts/1#summary-36649577373 

## Solution
Bump upstream source tags to `1.24.3` before on-boarding to OCI factory
