### PR TITLE
remove entrypoint service

### DIFF
--- a/1.23.3/rockcraft.yaml
+++ b/1.23.3/rockcraft.yaml
@@ -7,10 +7,9 @@ description: |
 platforms:
   amd64:
 
-entrypoint-service: ztunnel
 services:
   ztunnel:
-    command: /bin/ztunnel [ ]
+    command: /bin/ztunnel proxy
     override: replace
     startup: enabled
 

--- a/1.24.3/rockcraft.yaml
+++ b/1.24.3/rockcraft.yaml
@@ -7,10 +7,9 @@ description: |
 platforms:
   amd64:
 
-entrypoint-service: ztunnel
 services:
   ztunnel:
-    command: /bin/ztunnel [ ]
+    command: /bin/ztunnel proxy
     override: replace
     startup: enabled
 


### PR DESCRIPTION
## Issue
The `entrypoint serivce` in the rockcraft files seems to be redundant, building `ztunnel` locally and running the help arg returns the below

```
./ztunnel help

Istio Ztunnel (version.BuildInfo{Version:"87aa1e934c6f7be02054b57fdf7a1602653b528c", GitRevision:"87aa1e934c6f7be02054b57fdf7a1602653b528c", RustVersion:"1.84.1", BuildProfile:"debug", BuildStatus:"Clean", GitTag:"1.25.0-alpha.0-15-g87aa1e9", IstioVersion:"unknown"})

Commands:
proxy (default) - Start the ztunnel proxy
version         - Print the version of ztunnel
help            - Print commands and version of ztunnel
```

Meaning the binary can just be called with or without the `proxy` command and should work as expected.